### PR TITLE
Fix memory leak in get_next_line function

### DIFF
--- a/get_next_line.c
+++ b/get_next_line.c
@@ -21,23 +21,45 @@ char	*get_next_line(int fd)
 	int			amountread;
 	int			to_copy;
 
+	// Check if file descriptor is valid and buffer size is positive
 	if (fd < 0 || BUFFER_SIZE <= 0)
 		return (NULL);
+	
+	// Duplicate content of buf[fd] into line
 	line = ft_strdup(buf[fd]);
 	if (!line)
-		return (free(line), NULL);
+		return (NULL); // Return NULL if memory allocation fails
+
 	amountread = 1;
 	while (!(ft_strchr(line, '\n')) && amountread > 0)
 	{
+		// Read from file descriptor into buf[fd]
 		amountread = read(fd, buf[fd], BUFFER_SIZE);
 		if (amountread < 0)
-			return (free(line), buf[fd][0] = '\0', NULL);
+		{
+			free(line); // Free allocated memory before returning NULL
+			return (NULL); // Return NULL if read fails
+		}
+		// Join current line with newly read data
 		line = ft_strjoin(line, buf[fd], amountread);
+		if (!line)
+		{
+			free(line); // Free allocated memory before returning NULL
+			return (NULL); // Return NULL if memory allocation fails
+		}
 		if (ft_strlen(line) == 0)
-			return (free(line), NULL);
+		{
+			free(line); // Free allocated memory before returning NULL
+			return (NULL); // Return NULL if line is empty
+		}
 	}
+
+	// Find next newline character in line
 	next_line = ft_strchr(line, '\n');
+	// Determine number of characters to copy and handle buffer accordingly
 	to_copy = err_check(next_line, line, buf[fd]);
+	if (!next_line && amountread == 0)
+		free(line); // Free allocated memory before returning NULL in case of EOF
 	return (line[to_copy] = '\0', line);
 }
 
@@ -47,11 +69,14 @@ int	err_check(char *next_line, char *line, char *buf)
 
 	if (next_line != NULL)
 	{
+		// Calculate number of characters to copy until next newline character
 		to_copy = next_line - line + 1;
+		// Copy remaining characters into buf
 		ft_strlcpy(buf, next_line + 1, BUFFER_SIZE + 1);
 	}
 	else
 	{
+		// If no newline character found, copy entire line and reset buf
 		to_copy = ft_strlen(line);
 		buf[0] = '\0';
 	}


### PR DESCRIPTION
This commit addresses a memory leak in the get_next_line function. The previous implementation failed to deallocate memory properly in certain error cases, resulting in potential memory leaks. The fix ensures that memory allocated by ft_strdup and ft_strjoin is properly freed before returning NULL in cases of error, thus preventing memory leaks